### PR TITLE
Change filename of marginPhase output

### DIFF
--- a/wdl/workflows/marginPhase.wdl
+++ b/wdl/workflows/marginPhase.wdl
@@ -105,11 +105,11 @@ task marginPhase {
         samtools index -@ ~{threads} ~{bamFile}
         samtools faidx ~{refFile}
         mkdir output/
-        margin phase ~{bamFile} ~{refFile} ~{combinedVcfFile} /opt/margin/params/phase/allParams.phase_vcf.ont.sv.json -t ~{threads} ~{marginOtherArgs} -o output/~{sampleName} -M
-        bgzip output/~{sampleName}.phased.vcf
+        margin phase ~{bamFile} ~{refFile} ~{combinedVcfFile} /opt/margin/params/phase/allParams.phase_vcf.ont.sv.json -t ~{threads} ~{marginOtherArgs} -o output/~{sampleName}_hvcf -M
+        bgzip output/~{sampleName}_hvcf.phased.vcf
     >>>
     output {
-        File phasedVcf = "output/~{sampleName}.phased.vcf.gz"
+        File phasedVcf = "output/~{sampleName}_hvcf.phased.vcf.gz"
         File? toplog = "top.log"
     }
 


### PR DESCRIPTION
When running the `cardEndToEndVcf.wdl` on a cluster with toil (using `--batchSystem slurm`), all workflow outputs are dumped in a single directory, and files with identical names are not automatically distinguished, leading to overwriting. This results in 8 files instead of the expected 9 files.

So, changing the filename for the "harmonized_vcf" can help resolve this issue for toil users.
To address this issue specifically for Toil users (not a problem for Terra users since each task gets its own submission directory), changing the filename for "harmonized_vcf" will avoid conflicts with the filename for "smallVariants_vcf". Currently, both are named `<sample-name>.phased.vcf`